### PR TITLE
Update to nrfxlib 3.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrfxlib-sys"
-version = "3.0.3+3.0.2"
+version = "3.1.0+3.3.0"
 authors = [
 	"Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
 	"42 Technology Ltd <jonathan.pallant@42technology.com>",
@@ -25,6 +25,8 @@ include = [
 	"third_party/nordic/nrfxlib/nrf_modem/lib/cellular/nrf9120/hard-float/libmodem_log.a",
 	"third_party/nordic/nrfxlib/nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem.a",
 	"third_party/nordic/nrfxlib/nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem_log.a",
+	"third_party/nordic/nrfxlib/nrf_modem/lib/dect/nrf9120/hard-float/libmodem.a",
+	"third_party/nordic/nrfxlib/nrf_modem/lib/dect/nrf9120/hard-float/libmodem_log.a",
 	"third_party/nordic/nrfxlib/nrf_modem/include/**",
 	"third_party/nordic/nrfxlib/nrf_modem/license.txt",
 	"third_party/nordic/nrfxlib/nrf_modem/README.rst",
@@ -54,13 +56,29 @@ arm-none-eabi-objcopy = []
 llvm-objcopy = ["dep:llvm-tools"]
 log = []
 
-## Links the DECT modem library
+## Links the DECT PHY modem library variant (lib/dect_phy/libmodem.a)
 ##
-## This exposes the same set of headers, but internally uses a different
-## libmodem.a library, which is used with considerable differences. Note that
-## using this also requires using an alternative radio core firmware, which is
-## not shipped in crates.
-dect = []
+## Pair with the DECT PHY radio-core firmware. Exposes the PHY API
+## (`nrf_modem_dect_phy_*`) and the clock sync API
+## (`nrf_modem_dect_clock_sync_*`). Mutually exclusive with `dect-mac`.
+##
+## The radio-core firmware is not shipped in this crate.
+dect-phy = []
+
+## Links the DECT NR+ MAC/DLC modem library variant (lib/dect/libmodem.a,
+## libmodem 3.3.0+)
+##
+## Pair with the DECT NR+ (MAC) radio-core firmware. Symbol-wise this is a
+## strict superset of `dect-phy`: it exports the same PHY + clock_sync
+## symbols and additionally the MAC (`nrf_modem_dect_mac_*`), DLC
+## (`nrf_modem_dect_dlc_*`), and control (`nrf_modem_dect_control_*`)
+## surfaces declared in `nrf_modem_dect.h`. Mutually exclusive with
+## `dect-phy`.
+##
+## Note: `nrf_modem_dect.h` is distributed under a more restrictive license
+## than the rest of nrfxlib (Nordic confidential). Confirm your usage rights
+## with Nordic before enabling this feature in a shipping product.
+dect-mac = []
 
 nrf9160 = []
 nrf9151 = ["nrf9120"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ dect = ["dect-phy"]
 ##
 ## Pair with the DECT PHY radio-core firmware. Exposes the PHY API
 ## (`nrf_modem_dect_phy_*`) and the clock sync API
-## (`nrf_modem_dect_clock_sync_*`). Mutually exclusive with `dect-mac`.
+## (`nrf_modem_dect_clock_sync_*`).
 ##
 ## The radio-core firmware is not shipped in this crate.
 dect-phy = []
@@ -71,12 +71,11 @@ dect-phy = []
 ## Links the DECT NR+ MAC/DLC modem library variant (lib/dect/libmodem.a,
 ## libmodem 3.3.0+)
 ##
-## Pair with the DECT NR+ (MAC) radio-core firmware. Symbol-wise this is a
+## Pair with the DECT NR+ (MAC) radio-core firmware. This is a
 ## strict superset of `dect-phy`: it exports the same PHY + clock_sync
 ## symbols and additionally the MAC (`nrf_modem_dect_mac_*`), DLC
 ## (`nrf_modem_dect_dlc_*`), and control (`nrf_modem_dect_control_*`)
-## surfaces declared in `nrf_modem_dect.h`. Mutually exclusive with
-## `dect-phy`.
+## surfaces declared in `nrf_modem_dect.h`.
 ##
 ## Note: `nrf_modem_dect.h` is distributed under a more restrictive license
 ## than the rest of nrfxlib (Nordic confidential). Confirm your usage rights

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ arm-none-eabi-objcopy = []
 llvm-objcopy = ["dep:llvm-tools"]
 log = []
 
+## Deprecated alias for the `dect-phy` feature.
+dect = ["dect-phy"]
+
 ## Links the DECT PHY modem library variant (lib/dect_phy/libmodem.a)
 ##
 ## Pair with the DECT PHY radio-core firmware. Exposes the PHY API

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,15 @@ compile_error!(
     "
 );
 
+#[cfg(not(any(feature = "arm-none-eabi-objcopy", feature = "llvm-objcopy")))]
+compile_error!(
+	"No objcopy feature selected. The build script needs one to stage `libmodem.a` into OUT_DIR. \
+	Enable exactly one of:
+    llvm-objcopy            (default; uses `llvm-objcopy`),
+    arm-none-eabi-objcopy   (uses `arm-none-eabi-objcopy`).
+    "
+);
+
 fn main() {
 	use std::env;
 	use std::path::{Path, PathBuf};
@@ -98,28 +107,49 @@ fn main() {
 	let bindings_out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
 	std::fs::write(bindings_out_path, rust_source).expect("Couldn't write updated bindgen output");
 
-	#[cfg(all(feature = "nrf9160", not(feature = "dect")))]
+	#[cfg(all(
+		feature = "nrf9160",
+		not(feature = "dect-phy"),
+		not(feature = "dect-mac")
+	))]
 	let libmodem_original_path = if cfg!(feature = "log") {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9160/hard-float/libmodem_log.a")
 	} else {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9160/hard-float/libmodem.a")
 	};
 
-	#[cfg(all(feature = "nrf9120", not(feature = "dect")))]
+	#[cfg(all(
+		feature = "nrf9120",
+		not(feature = "dect-phy"),
+		not(feature = "dect-mac")
+	))]
 	let libmodem_original_path = if cfg!(feature = "log") {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9120/hard-float/libmodem_log.a")
 	} else {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9120/hard-float/libmodem.a")
 	};
 
-	#[cfg(all(feature = "nrf9160", feature = "dect"))]
-	panic!("The DECT library is not available for the nRF9160 series.");
+	#[cfg(all(feature = "nrf9160", feature = "dect-phy"))]
+	compile_error!("The DECT library is not available for the nRF9160 series.");
 
-	#[cfg(all(feature = "nrf9120", feature = "dect"))]
+	#[cfg(all(feature = "nrf9160", feature = "dect-mac"))]
+	compile_error!("The DECT MAC library is not available for the nRF9160 series.");
+
+	#[cfg(all(feature = "dect-phy", feature = "dect-mac"))]
+	compile_error!("Features `dect-phy` and `dect-mac` are mutually exclusive - pick one.");
+
+	#[cfg(all(feature = "nrf9120", feature = "dect-phy", not(feature = "dect-mac")))]
 	let libmodem_original_path = if cfg!(feature = "log") {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem_log.a")
 	} else {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem.a")
+	};
+
+	#[cfg(all(feature = "nrf9120", feature = "dect-mac", not(feature = "dect-phy")))]
+	let libmodem_original_path = if cfg!(feature = "log") {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect/nrf9120/hard-float/libmodem_log.a")
+	} else {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect/nrf9120/hard-float/libmodem.a")
 	};
 
 	let libmodem_changed_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("libmodem.a");
@@ -185,6 +215,6 @@ fn main() {
 			.display()
 	);
 	println!("cargo:rustc-link-lib=static=modem");
-	println!("cargo:rustc-link-lib=static=oberon_3.0.16");
+	println!("cargo:rustc-link-lib=static=oberon_3.0.19");
 	println!("cargo:rustc-link-lib=static=nrf_cc310_platform_0.9.19");
 }

--- a/build.rs
+++ b/build.rs
@@ -135,9 +135,6 @@ fn main() {
 	#[cfg(all(feature = "nrf9160", feature = "dect-mac"))]
 	compile_error!("The DECT MAC library is not available for the nRF9160 series.");
 
-	#[cfg(all(feature = "dect-phy", feature = "dect-mac"))]
-	compile_error!("Features `dect-phy` and `dect-mac` are mutually exclusive - pick one.");
-
 	#[cfg(all(feature = "nrf9120", feature = "dect-phy", not(feature = "dect-mac")))]
 	let libmodem_original_path = if cfg!(feature = "log") {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem_log.a")
@@ -145,7 +142,7 @@ fn main() {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem.a")
 	};
 
-	#[cfg(all(feature = "nrf9120", feature = "dect-mac", not(feature = "dect-phy")))]
+	#[cfg(all(feature = "nrf9120", feature = "dect-mac"))]
 	let libmodem_original_path = if cfg!(feature = "log") {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect/nrf9120/hard-float/libmodem_log.a")
 	} else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,16 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![allow(clippy::missing_safety_doc)]
+// bindgen-generated bitfield accessors transmute small ints to/from themselves.
+#![allow(clippy::useless_transmute)]
+// bindgen converts Doxygen list items in a way that overindents under clippy's rule.
+#![allow(clippy::doc_overindented_list_items)]
+// bindgen emits wide-arity bitfield constructors for the new DECT MAC structs.
+#![allow(clippy::too_many_arguments)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+// Compat shim: libmodem 3.3 renamed `NRF_MODEM_DECT_PHY_SHMEM_CTRL_SIZE` to
+// `NRF_MODEM_DECT_SHMEM_CTRL_SIZE`. Keep the old name available so downstream
+// crates (notably `nrf-modem`) continue to compile against this version.
+pub const NRF_MODEM_DECT_PHY_SHMEM_CTRL_SIZE: u32 = NRF_MODEM_DECT_SHMEM_CTRL_SIZE;

--- a/wrapper.h
+++ b/wrapper.h
@@ -16,6 +16,9 @@
 #include "nrf_modem/include/nrf_modem_trace.h"
 #include "nrf_modem/include/nrf_gai_errors.h"
 #include "nrf_modem/include/nrf_modem_dect_phy.h"
+#include "nrf_modem/include/nrf_modem_dect_clock_sync.h"
+#include "nrf_modem/include/nrf_modem_dect.h"
+#include "nrf_modem/include/nrf_modem_rs_capture.h"
 
 /*
  * Crypto Cell 310 (CC310) platform headers


### PR DESCRIPTION
Version 3.3.0 is not out yet (not even a release candidate, which they would tag, merely a -prerelease1 in the docs and the latest main), but it contains quite important additions on the DECT side.

This PR will stay a draft PR until there is some tagged version we can follow, but I'll use it for exploration already, to hammer out the usual upgrading troubles (like finding changes like the oberon version bump), and also to find out whether this should be 3.1.0-alpha.0+3.3.0-git8694a4dd or 4.0.0-alpha.0+3.3.0-git8694a4dd.